### PR TITLE
Add support for uuid or id based records

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -3,6 +3,7 @@ class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migrat
     create_table(:<%= table_name %>) do |t|
       t.string :name
       t.references :resource, :polymorphic => true
+      t.uuid :resource_uuid
 
       t.timestamps
     end
@@ -13,6 +14,7 @@ class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migrat
     end
     <% if ActiveRecord::Base.connection.class.to_s.demodulize != 'PostgreSQLAdapter' %><%= "\n    " %>add_index(:<%= table_name %>, :name)<% end %>
     add_index(:<%= table_name %>, [ :name, :resource_type, :resource_id ])
+    add_index(:<%= table_name %>, [ :name, :resource_type, :resource_uuid ])
     add_index(:<%= join_table %>, [ :<%= user_reference %>_id, :<%= role_reference %>_id ])
   end
 end

--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -18,23 +18,26 @@ module Rolify
           str
         end
 
+        id_column = id_column_name(relation)
+
         resources = relation.joins("INNER JOIN #{quote_table(roles_table)} ON #{quote_table(roles_table)}.resource_type IN (#{relations}) AND
-                                    (#{quote_table(roles_table)}.resource_id IS NULL OR #{quote_table(roles_table)}.resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)})")
+                                    (#{quote_table(roles_table)}.#{id_column} IS NULL OR #{quote_table(roles_table)}.#{id_column} = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)})")
         resources = resources.where("#{quote_table(roles_table)}.name IN (?) AND #{quote_table(roles_table)}.resource_type IN (?)", Array(role_name), klasses)
-        resources = resources.select("#{quote_table(relation.table_name)}.*")
         resources
       end
 
       def in(relation, user, role_names)
         roles = user.roles.where(:name => role_names).select("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)}")
-        relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((#{quote_table(role_class.table_name)}.resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (#{quote_table(role_class.table_name)}.resource_id IS NULL))", roles)
+        id_column = id_column_name(relation)
+
+        relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((#{quote_table(role_class.table_name)}.#{id_column} = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (#{quote_table(role_class.table_name)}.#{id_column} IS NULL))", roles)
       end
 
       def applied_roles(relation, children)
         if children
-          relation.role_class.where('resource_type IN (?) AND resource_id IS NULL', self.relation_types_for(relation))
+          relation.role_class.where(resource_type: self.relation_types_for(relation), resource_id: nil, resource_uuid: nil)
         else
-          relation.role_class.where('resource_type = ? AND resource_id IS NULL', relation.to_s)
+          relation.role_class.where(resource_type: relation.to_s, resource_id: nil, resource_uuid: nil)
         end
       end
 
@@ -44,6 +47,14 @@ module Rolify
       end
 
       private
+
+      # Determines the appropriate ID column (resource_id or resource_uuid) based on the relation's primary key type
+      # Returns the column name as a string
+      def id_column_name(relation)
+        pk_column = relation.columns_hash[relation.primary_key]
+        uses_string_id = pk_column && pk_column.type.in?([:string, :uuid])
+        uses_string_id ? "resource_uuid" : "resource_id"
+      end
 
       def quote_column(column)
         ActiveRecord::Base.connection.quote_column_name column

--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -12,9 +12,12 @@ module Rolify
         wrap_conditions = relation.name != role_class.name
 
         conditions = if args[:resource].is_a?(Class)
-                       {:resource_type => args[:resource].to_s, :resource_id => nil }
+                       {:resource_type => args[:resource].to_s, :resource_id => nil, :resource_uuid => nil }
                      elsif args[:resource].present?
-                       {:resource_type => args[:resource].class.name, :resource_id => args[:resource].id}
+                       id_field = resource_id_field(args[:resource])
+                       base_conditions = {:resource_type => args[:resource].class.name}
+                       base_conditions.merge!(id_field => args[:resource].id)
+                       base_conditions
                      else
                        {}
                      end
@@ -28,27 +31,44 @@ module Rolify
       def find_cached(relation, args)
         resource_id = (args[:resource].nil? || args[:resource].is_a?(Class) || args[:resource] == :any) ? nil : args[:resource].id
         resource_type = args[:resource].is_a?(Class) ? args[:resource].to_s : args[:resource].class.name
+        is_string_id = resource_id && string_id?(resource_id)
 
         return relation.find_all { |role| role.name == args[:name].to_s } if args[:resource] == :any
 
         relation.find_all do |role|
-          (role.name == args[:name].to_s && role.resource_type == nil && role.resource_id == nil) ||
-          (role.name == args[:name].to_s && role.resource_type == resource_type && role.resource_id == nil) ||
-          (role.name == args[:name].to_s && role.resource_type == resource_type && role.resource_id == resource_id)
+          (role.name == args[:name].to_s && role.resource_type == nil && role.resource_id == nil && role.resource_uuid == nil) ||
+          (role.name == args[:name].to_s && role.resource_type == resource_type && role.resource_id == nil && role.resource_uuid == nil) ||
+          (is_string_id && role.name == args[:name].to_s && role.resource_type == resource_type && role.resource_uuid == resource_id) ||
+          (!is_string_id && role.name == args[:name].to_s && role.resource_type == resource_type && role.resource_id == resource_id)
         end
       end
 
       def find_cached_strict(relation, args)
         resource_id = (args[:resource].nil? || args[:resource].is_a?(Class)) ? nil : args[:resource].id
         resource_type = args[:resource].is_a?(Class) ? args[:resource].to_s : args[:resource].class.name
+        is_string_id = resource_id && string_id?(resource_id)
 
         relation.find_all do |role|
-          role.resource_id == resource_id && role.resource_type == resource_type && role.name == args[:name].to_s
+          if is_string_id
+            role.resource_uuid == resource_id && role.resource_id == nil && role.resource_type == resource_type && role.name == args[:name].to_s
+          else
+            role.resource_id == resource_id && role.resource_uuid == nil && role.resource_type == resource_type && role.name == args[:name].to_s
+          end
         end
       end
 
       def find_or_create_by(role_name, resource_type = nil, resource_id = nil)
-        role_class.where(:name => role_name, :resource_type => resource_type, :resource_id => resource_id).first_or_create
+        conditions = { :name => role_name, :resource_type => resource_type }
+
+        if resource_id && string_id?(resource_id)
+          conditions[:resource_uuid] = resource_id
+          conditions[:resource_id] = nil
+        else
+          conditions[:resource_id] = resource_id
+          conditions[:resource_uuid] = nil
+        end
+
+        role_class.where(conditions).first_or_create
       end
 
       def add(relation, role)
@@ -57,8 +77,19 @@ module Rolify
 
       def remove(relation, role_name, resource = nil)
         cond = { :name => role_name }
-        cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name) if resource
-        cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
+        if resource
+          cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name)
+          if !resource.is_a?(Class)
+            id_field = resource_id_field(resource)
+            if id_field == :resource_uuid
+              cond[:resource_uuid] = resource.id
+              cond[:resource_id] = nil
+            else
+              cond[:resource_id] = resource.id
+              cond[:resource_uuid] = nil
+            end
+          end
+        end
         roles = relation.roles.where(cond)
         if roles
           relation.roles.delete(roles)
@@ -85,6 +116,23 @@ module Rolify
 
       private
 
+      def string_id?(id)
+        id.is_a?(String)
+      end
+
+      def resource_id_field(resource)
+        return if resource.nil? || resource.is_a?(Class)
+        return :resource_uuid if string_id?(resource.id)
+        
+        :resource_id
+      end
+
+      def resource_id_value(resource)
+        return if resource.nil? || resource.is_a?(Class)
+        
+        resource.id
+      end
+
       def build_conditions(relation, args)
         conditions = []
         values = []
@@ -105,14 +153,15 @@ module Rolify
 
       def build_query(role, resource = nil)
         return [ "#{role_table}.name = ?", [ role ] ] if resource == :any
-        query = "((#{role_table}.name = ?) AND (#{role_table}.resource_type IS NULL) AND (#{role_table}.resource_id IS NULL))"
+        query = "((#{role_table}.name = ?) AND (#{role_table}.resource_type IS NULL) AND (#{role_table}.resource_id IS NULL) AND (#{role_table}.resource_uuid IS NULL))"
         values = [ role ]
         if resource
           query.insert(0, "(")
-          query += " OR ((#{role_table}.name = ?) AND (#{role_table}.resource_type = ?) AND (#{role_table}.resource_id IS NULL))"
+          query += " OR ((#{role_table}.name = ?) AND (#{role_table}.resource_type = ?) AND (#{role_table}.resource_id IS NULL) AND (#{role_table}.resource_uuid IS NULL))"
           values << role << (resource.is_a?(Class) ? resource.to_s : resource.class.name)
           if !resource.is_a? Class
-            query += " OR ((#{role_table}.name = ?) AND (#{role_table}.resource_type = ?) AND (#{role_table}.resource_id = ?))"
+            id_field = resource_id_field(resource)
+            query += " OR ((#{role_table}.name = ?) AND (#{role_table}.resource_type = ?) AND (#{role_table}.#{id_field} = ?))"
             values << role << resource.class.name << resource.id
           end
           query += ")"

--- a/lib/rolify/adapters/active_record/scopes.rb
+++ b/lib/rolify/adapters/active_record/scopes.rb
@@ -2,22 +2,27 @@ module Rolify
   module Adapter
     module Scopes
       def global
-        where(:resource_type => nil, :resource_id => nil)
+        where(:resource_type => nil, :resource_id => nil, :resource_uuid => nil)
       end
-      
+
       def class_scoped(resource_type = nil)
-        where_conditions = "resource_type IS NOT NULL AND resource_id IS NULL"
-        where_conditions = [ "resource_type = ? AND resource_id IS NULL", resource_type.name ] if resource_type
+        where_conditions = "resource_type IS NOT NULL AND resource_id IS NULL AND resource_uuid IS NULL"
+        where_conditions = [ "resource_type = ? AND resource_id IS NULL AND resource_uuid IS NULL", resource_type.name ] if resource_type
         where(where_conditions)
       end
-      
+
       def instance_scoped(resource_type = nil)
-        where_conditions = "resource_type IS NOT NULL AND resource_id IS NOT NULL"
+        where_conditions = "resource_type IS NOT NULL AND (resource_id IS NOT NULL OR resource_uuid IS NOT NULL)"
         if resource_type
           if resource_type.is_a? Class
-            where_conditions = [ "resource_type = ? AND resource_id IS NOT NULL", resource_type.name ]
+            where_conditions = [ "resource_type = ? AND (resource_id IS NOT NULL OR resource_uuid IS NOT NULL)", resource_type.name ]
           else
-            where_conditions = [ "resource_type = ? AND resource_id = ?", resource_type.class.name, resource_type.id ]
+            # Check if the resource ID is a string (UUID) or integer
+            if resource_type.id.is_a?(String)
+              where_conditions = [ "resource_type = ? AND resource_uuid = ?", resource_type.class.name, resource_type.id ]
+            else
+              where_conditions = [ "resource_type = ? AND resource_id = ?", resource_type.class.name, resource_type.id ]
+            end
           end
         end
         where(where_conditions)

--- a/spec/rolify/uuid_resource_spec.rb
+++ b/spec/rolify/uuid_resource_spec.rb
@@ -1,0 +1,297 @@
+require "spec_helper"
+
+describe "Rolify with UUID resources" do
+  if ENV['ADAPTER'] == 'active_record'
+    before(:all) do
+      License.resourcify :roles, :role_cname => "Role"
+      Role.destroy_all
+    end
+
+    let(:user) { User.first }
+    let(:license) { License.first }
+
+    before(:each) do
+      Role.destroy_all
+    end
+
+    context "with UUID primary keys" do
+      describe "adding roles" do
+        it "creates role with resource_uuid instead of resource_id" do
+          user.add_role(:admin, license)
+
+          role = Role.last
+          expect(role.name).to eq("admin")
+          expect(role.resource_type).to eq("License")
+          expect(role.resource_id).to be_nil
+          expect(role.resource_uuid).to eq(license.id)
+          expect(role.resource_uuid).to be_a(String)
+        end
+
+        it "creates class scoped role with resource_uuid nil" do
+          user.add_role(:manager, License)
+
+          role = Role.last
+          expect(role.name).to eq("manager")
+          expect(role.resource_type).to eq("License")
+          expect(role.resource_id).to be_nil
+          expect(role.resource_uuid).to be_nil
+        end
+
+        it "creates global role with both resource columns nil" do
+          user.add_role(:admin)
+
+          role = Role.last
+          expect(role.name).to eq("admin")
+          expect(role.resource_type).to be_nil
+          expect(role.resource_id).to be_nil
+          expect(role.resource_uuid).to be_nil
+        end
+      end
+
+      describe "#has_role?" do
+        before { user.add_role(:admin, license) }
+
+        it "returns true for instance scoped role" do
+          expect(user.has_role?(:admin, license)).to be true
+        end
+
+        it "returns true with :any parameter" do
+          expect(user.has_role?(:admin, :any)).to be true
+        end
+
+        it "returns true when checking class scope" do
+          expect(user.has_role?(:admin, License.first)).to be true
+        end
+
+        it "returns false for different license" do
+          other_license = License.last
+          expect(user.has_role?(:admin, other_license)).to be false
+        end
+
+        it "returns false for wrong role name" do
+          expect(user.has_role?(:moderator, license)).to be false
+        end
+
+        it "distinguishes between UUID and integer resources" do
+          forum = Forum.first
+          user.add_role(:admin, forum)
+
+          # Should have role on forum (integer ID)
+          expect(user.has_role?(:admin, forum)).to be true
+          # Still has role on license (UUID)
+          expect(user.has_role?(:admin, license)).to be true
+
+          # Check the roles were stored correctly
+          license_role = user.roles.find_by(resource_type: 'License')
+          forum_role = user.roles.find_by(resource_type: 'Forum')
+
+          expect(license_role.resource_uuid).to eq(license.id)
+          expect(license_role.resource_id).to be_nil
+          expect(forum_role.resource_id).to eq(forum.id)
+          expect(forum_role.resource_uuid).to be_nil
+        end
+      end
+
+      describe "#has_cached_role?" do
+        before { user.add_role(:moderator, license) }
+
+        it "returns true for instance scoped role with preloaded roles" do
+          cached_user = User.includes(:roles).find(user.id)
+          expect(cached_user.has_cached_role?(:moderator, license)).to be true
+        end
+
+        it "returns true with :any parameter" do
+          cached_user = User.includes(:roles).find(user.id)
+          expect(cached_user.has_cached_role?(:moderator, :any)).to be true
+        end
+
+        it "returns false for different license" do
+          cached_user = User.includes(:roles).find(user.id)
+          other_license = License.last
+          expect(cached_user.has_cached_role?(:moderator, other_license)).to be false
+        end
+
+        it "works correctly with mixed UUID and integer resources" do
+          forum = Forum.first
+          user.add_role(:moderator, forum)
+
+          cached_user = User.includes(:roles).find(user.id)
+          expect(cached_user.has_cached_role?(:moderator, license)).to be true
+          expect(cached_user.has_cached_role?(:moderator, forum)).to be true
+        end
+      end
+
+      describe "scopes" do
+        describe ".global" do
+          it "returns only global roles" do
+            global_role = user.add_role(:admin)
+            user.add_role(:manager, license)
+
+            expect(user.roles.global).to eq([global_role])
+          end
+        end
+
+        describe ".class_scoped" do
+          it "returns class scoped roles for UUID resources" do
+            class_role = user.add_role(:manager, License)
+            user.add_role(:admin, license)
+
+            expect(user.roles.class_scoped).to include(class_role)
+            expect(user.roles.class_scoped(License)).to eq([class_role])
+          end
+
+          it "does not return instance scoped UUID roles" do
+            user.add_role(:admin, license)
+
+            expect(user.roles.class_scoped(License)).to be_empty
+          end
+        end
+
+        describe ".instance_scoped" do
+          it "returns instance scoped roles for UUID resources" do
+            instance_role = user.add_role(:visitor, license)
+            user.add_role(:manager, License)
+
+            expect(user.roles.instance_scoped).to include(instance_role)
+            expect(user.roles.instance_scoped(License)).to include(instance_role)
+          end
+
+          it "filters by specific UUID resource" do
+            license1_role = user.add_role(:visitor, License.first)
+            license2_role = user.add_role(:visitor, License.last)
+
+            expect(user.roles.instance_scoped(License.first)).to eq([license1_role])
+            expect(user.roles.instance_scoped(License.last)).to eq([license2_role])
+          end
+
+          it "works with both UUID and integer resources" do
+            license_role = user.add_role(:visitor, license)
+            forum_role = user.add_role(:visitor, Forum.first)
+
+            all_instance_roles = user.roles.instance_scoped
+            expect(all_instance_roles).to include(license_role, forum_role)
+          end
+        end
+      end
+
+      describe "#remove_role" do
+        it "removes role from UUID resource" do
+          user.add_role(:admin, license)
+          expect(user.has_role?(:admin, license)).to be true
+
+          user.remove_role(:admin, license)
+          expect(user.has_role?(:admin, license)).to be false
+        end
+
+        it "removes correct role when multiple UUID resources exist" do
+          user.add_role(:admin, License.first)
+          user.add_role(:admin, License.last)
+
+          user.remove_role(:admin, License.first)
+
+          expect(user.has_role?(:admin, License.first)).to be false
+          expect(user.has_role?(:admin, License.last)).to be true
+        end
+
+        it "only removes UUID role, not integer role with same name" do
+          user.add_role(:admin, license)
+          user.add_role(:admin, Forum.first)
+
+          user.remove_role(:admin, license)
+
+          expect(user.has_role?(:admin, license)).to be false
+          expect(user.has_role?(:admin, Forum.first)).to be true
+        end
+      end
+
+      describe "Resource.with_role" do
+        it "finds UUID resources with specific role" do
+          user.add_role(:admin, License.first)
+          user.add_role(:admin, License.second)
+
+          admins = License.with_role(:admin, user)
+          expect(admins).to include(License.first, License.second)
+          expect(admins).not_to include(License.last)
+        end
+
+        it "finds UUID resources with class scoped role" do
+          user.add_role(:manager, License)
+
+          managers = License.with_role(:manager, user)
+          expect(managers.count).to eq(License.count)
+        end
+
+        it "finds integer ID resources with specific role" do
+          Forum.resourcify :roles, :role_cname => "Role"
+          user.add_role(:moderator, Forum.first)
+          user.add_role(:moderator, Forum.second)
+
+          moderators = Forum.with_role(:moderator, user)
+          expect(moderators).to include(Forum.first, Forum.second)
+          expect(moderators).not_to include(Forum.last)
+        end
+
+        it "finds integer ID resources with class scoped role" do
+          Forum.resourcify :roles, :role_cname => "Role"
+          user.add_role(:editor, Forum)
+
+          editors = Forum.with_role(:editor, user)
+          expect(editors.count).to eq(Forum.count)
+        end
+      end
+
+      describe "mixed UUID and integer ID resources" do
+        before(:all) do
+          Forum.resourcify :roles, :role_cname => "Role"
+        end
+
+        it "correctly distinguishes between UUID and integer resources in queries" do
+          # Add roles to both UUID and integer ID resources
+          user.add_role(:owner, license)
+          user.add_role(:owner, Forum.first)
+
+          # Query each type separately
+          license_owners = License.with_role(:owner, user)
+          forum_owners = Forum.with_role(:owner, user)
+
+          # Verify they return the correct resources
+          expect(license_owners).to include(license)
+          expect(license_owners.to_a).not_to include(Forum.first)
+          expect(forum_owners).to include(Forum.first)
+          expect(forum_owners.to_a).not_to include(license)
+        end
+
+        it "maintains separate role storage for UUID vs integer IDs" do
+          # Create roles on both types
+          user.add_role(:contributor, license)
+          user.add_role(:contributor, Forum.first)
+
+          # Check the roles were stored with correct ID columns
+          license_role = Role.find_by(name: 'contributor', resource_type: 'License')
+          forum_role = Role.find_by(name: 'contributor', resource_type: 'Forum')
+
+          expect(license_role.resource_uuid).to eq(license.id)
+          expect(license_role.resource_id).to be_nil
+          expect(forum_role.resource_id).to eq(Forum.first.id)
+          expect(forum_role.resource_uuid).to be_nil
+        end
+      end
+
+      describe "empty table handling" do
+        it "handles empty UUID resource tables correctly" do
+          # Delete all licenses to test with empty table
+          License.delete_all
+
+          # Add a class-scoped role (no specific license instance)
+          user.add_role(:viewer, License)
+
+          # Should return empty relation without errors
+          # The key is that it doesn't fail when determining column type on empty table
+          viewers = License.with_role(:viewer, user)
+          expect(viewers.count).to eq(0)
+          expect(viewers).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/support/adapters/active_record.rb
+++ b/spec/support/adapters/active_record.rb
@@ -12,9 +12,17 @@ class User < ActiveRecord::Base
   rolify
 end
 
+# Join table model for users_roles
+class UsersRole < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :role
+end
+
 class Role < ActiveRecord::Base
-  has_and_belongs_to_many :users, :join_table => :users_roles
-  has_and_belongs_to_many :strict_users, :join_table => :strict_users_roles
+  has_many :users_roles
+  has_many :users, through: :users_roles
+  has_many :strict_users_roles
+  has_many :strict_users, through: :strict_users_roles
 
   belongs_to :resource, :polymorphic => true
 
@@ -26,10 +34,22 @@ class StrictUser < ActiveRecord::Base
   rolify strict: true
 end
 
+# Join table model for strict_users_roles
+class StrictUsersRole < ActiveRecord::Base
+  belongs_to :strict_user
+  belongs_to :role
+end
+
 # Resourcifed and rolifed at the same time
 class HumanResource < ActiveRecord::Base
   resourcify :resources
   rolify
+end
+
+# Join table model for human_resources_roles
+class HumanResourcesRole < ActiveRecord::Base
+  belongs_to :human_resource
+  belongs_to :role
 end
 
 # Custom role and class names
@@ -37,8 +57,15 @@ class Customer < ActiveRecord::Base
   rolify :role_cname => "Privilege"
 end
 
+# Join table model for customers_privileges
+class CustomersPrivilege < ActiveRecord::Base
+  belongs_to :customer
+  belongs_to :privilege, class_name: "Privilege"
+end
+
 class Privilege < ActiveRecord::Base
-  has_and_belongs_to_many :customers, :join_table => :customers_privileges
+  has_many :customers_privileges
+  has_many :customers, through: :customers_privileges, source: :customer
   belongs_to :resource, :polymorphic => true
 
   extend Rolify::Adapter::Scopes
@@ -54,8 +81,16 @@ module Admin
     rolify :role_cname => "Admin::Right", :role_join_table_name => "moderators_rights"
   end
 
+  # Join table model for moderators_rights
+  class ModeratorsRight < ActiveRecord::Base
+    self.table_name = "moderators_rights"
+    belongs_to :moderator, class_name: "Admin::Moderator"
+    belongs_to :right, class_name: "Admin::Right"
+  end
+
   class Right < ActiveRecord::Base
-    has_and_belongs_to_many :moderators, :class_name => "Admin::Moderator", :join_table => "moderators_rights"
+    has_many :moderators_rights, class_name: "Admin::ModeratorsRight"
+    has_many :moderators, through: :moderators_rights, class_name: "Admin::Moderator"
     belongs_to :resource, :polymorphic => true
 
     extend Rolify::Adapter::Scopes
@@ -89,4 +124,8 @@ end
 
 class Company < Organization
 
+end
+
+class License < ActiveRecord::Base
+  # UUID primary key model for testing UUID resource support
 end

--- a/spec/support/data.rb
+++ b/spec/support/data.rb
@@ -26,3 +26,9 @@ Team.create(:team_code => "2", :name => "MU")
 
 Organization.create
 Company.create
+
+require 'securerandom'
+
+License.create(:id => SecureRandom.uuid, :name => "license 1")
+License.create(:id => SecureRandom.uuid, :name => "license 2")
+License.create(:id => SecureRandom.uuid, :name => "license 3")

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
     create_table(table) do |t|
     t.string :name
     t.references :resource, :polymorphic => true
+    t.string :resource_uuid
 
     t.timestamps null: false
     end
@@ -57,5 +58,12 @@ ActiveRecord::Schema.define do
 
   create_table(:organizations) do |t|
     t.string :type
+  end
+
+  # Use string primary key to simulate UUID (SQLite3 doesn't support native UUID)
+  create_table(:licenses, id: false) do |t|
+    t.string :id, primary_key: true
+    t.string :name
+    t.timestamps null: false
   end
 end


### PR DESCRIPTION
https://betterup.atlassian.net/browse/BUAPP-104765

As more records become UUID based, we'll need to be able to support both uuid and id types. Core api signed off on updating our fork of rolify to do that. [here's](https://betterup.slack.com/archives/C06RL6RRBU1/p1763501789233909) basically a summary of why I thought this was the right approach.

Corresponding Monolith PR: https://github.com/betterup/betterup-monolith/pull/22343/

Here's my new specs working locally, but the entire suite is still pretty messed up from the first PR merge of this fork
<img width="1343" height="698" alt="image" src="https://github.com/user-attachments/assets/6c4129c9-6ad0-4283-8551-8142532d8497" />